### PR TITLE
Automatically Fetch Data

### DIFF
--- a/src/data_generator.py
+++ b/src/data_generator.py
@@ -1,0 +1,28 @@
+import requests
+import json
+
+data_root = '../main_data/mcc_test'
+teams_file_path = f'{data_root}/mcc_test_teams.json'
+twitch_users_file_path = f'{data_root}/mcc_test_user_logins.json'
+youtube_users_file_path = f'{data_root}/mcc_test_yt_channels_info.json'
+mcc_name_file_path = f'./mcc.json'
+
+
+def main():
+    data = requests.get('https://mcc-data.memerson.xyz').json()
+
+    with open(teams_file_path, 'w') as file:
+        json.dump(data['teams'], file)
+
+    with open(twitch_users_file_path, 'w') as file:
+        json.dump(data['twitchUsers'], file)
+
+    with open(youtube_users_file_path, 'w') as file:
+        json.dump(data['youtubeUsers'], file)
+
+    with open(mcc_name_file_path, 'w') as file:
+        json.dump(data['event'], file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This code will automatically populate the data in the `main_data` folder and the `mcc.json` file. Since the MCC database is a Firestore database using the client SDK, it was very hard to translate the data calls to Python from JS. As such, I have simply created a small function on Vercel (code [here](https://github.com/memerson12/mcc-testing)) that will return the needed data in a JSON format. If wanted this could also be expanded to pull other kinds of data such as the current game, coin counts, timer, etc.